### PR TITLE
Add Maskable Recurrent PPO algorithm

### DIFF
--- a/sb3_contrib/__init__.py
+++ b/sb3_contrib/__init__.py
@@ -3,6 +3,7 @@ import os
 from sb3_contrib.ars import ARS
 from sb3_contrib.crossq import CrossQ
 from sb3_contrib.ppo_mask import MaskablePPO
+from sb3_contrib.ppo_mask_recurrent import MaskableRecurrentPPO
 from sb3_contrib.ppo_recurrent import RecurrentPPO
 from sb3_contrib.qrdqn import QRDQN
 from sb3_contrib.tqc import TQC
@@ -21,4 +22,5 @@ __all__ = [
     "CrossQ",
     "MaskablePPO",
     "RecurrentPPO",
+    "MaskableRecurrentPPO",
 ]

--- a/sb3_contrib/common/recurrent/maskable/buffers.py
+++ b/sb3_contrib/common/recurrent/maskable/buffers.py
@@ -1,0 +1,101 @@
+from typing import Optional
+
+import numpy as np
+import torch as th
+from gymnasium import spaces
+from stable_baselines3.common.vec_env import VecNormalize
+
+from sb3_contrib.common.recurrent.buffers import RecurrentDictRolloutBuffer, RecurrentRolloutBuffer
+from sb3_contrib.common.recurrent.type_aliases import (
+    MaskableRecurrentDictRolloutBufferSamples,
+    MaskableRecurrentRolloutBufferSamples,
+    RNNStates,
+)
+
+
+class MaskableRecurrentRolloutBuffer(RecurrentRolloutBuffer):
+    """Rollout buffer that stores LSTM states and action masks."""
+
+    def reset(self) -> None:
+        super().reset()
+        if isinstance(self.action_space, spaces.Discrete):
+            mask_dims = self.action_space.n
+        elif isinstance(self.action_space, spaces.MultiDiscrete):
+            mask_dims = sum(self.action_space.nvec)
+        elif isinstance(self.action_space, spaces.MultiBinary):
+            assert isinstance(self.action_space.n, int)
+            mask_dims = 2 * self.action_space.n
+        else:
+            raise ValueError(f"Unsupported action space {type(self.action_space)}")
+        self.mask_dims = mask_dims
+        self.action_masks = np.ones((self.buffer_size, self.n_envs, self.mask_dims), dtype=np.float32)
+
+    def add(self, *args, action_masks: Optional[np.ndarray] = None, lstm_states: RNNStates, **kwargs) -> None:  # type: ignore[override]
+        if action_masks is not None:
+            self.action_masks[self.pos] = action_masks.reshape((self.n_envs, self.mask_dims))
+        super().add(*args, lstm_states=lstm_states, **kwargs)
+
+    def _get_samples(
+        self,
+        batch_inds: np.ndarray,
+        env_change: np.ndarray,
+        env: Optional[VecNormalize] = None,
+    ) -> MaskableRecurrentRolloutBufferSamples:
+        data = super()._get_samples(batch_inds, env_change)
+        action_masks = th.as_tensor(self.action_masks[batch_inds], device=self.device).reshape(-1, self.mask_dims)
+        return MaskableRecurrentRolloutBufferSamples(
+            observations=data.observations,
+            actions=data.actions,
+            old_values=data.old_values,
+            old_log_prob=data.old_log_prob,
+            advantages=data.advantages,
+            returns=data.returns,
+            lstm_states=data.lstm_states,
+            episode_starts=data.episode_starts,
+            mask=data.mask,
+            action_masks=action_masks,
+        )
+
+
+class MaskableRecurrentDictRolloutBuffer(RecurrentDictRolloutBuffer):
+    """Dict version of :class:`MaskableRecurrentRolloutBuffer`."""
+
+    def reset(self) -> None:
+        super().reset()
+        if isinstance(self.action_space, spaces.Discrete):
+            mask_dims = self.action_space.n
+        elif isinstance(self.action_space, spaces.MultiDiscrete):
+            mask_dims = sum(self.action_space.nvec)
+        elif isinstance(self.action_space, spaces.MultiBinary):
+            assert isinstance(self.action_space.n, int)
+            mask_dims = 2 * self.action_space.n
+        else:
+            raise ValueError(f"Unsupported action space {type(self.action_space)}")
+        self.mask_dims = mask_dims
+        self.action_masks = np.ones((self.buffer_size, self.n_envs, self.mask_dims), dtype=np.float32)
+
+    def add(self, *args, action_masks: Optional[np.ndarray] = None, lstm_states: RNNStates, **kwargs) -> None:  # type: ignore[override]
+        if action_masks is not None:
+            self.action_masks[self.pos] = action_masks.reshape((self.n_envs, self.mask_dims))
+        super().add(*args, lstm_states=lstm_states, **kwargs)
+
+    def _get_samples(
+        self,
+        batch_inds: np.ndarray,
+        env_change: np.ndarray,
+        env: Optional[VecNormalize] = None,
+    ) -> MaskableRecurrentDictRolloutBufferSamples:
+        data = super()._get_samples(batch_inds, env_change)
+        action_masks = th.as_tensor(self.action_masks[batch_inds], device=self.device).reshape(-1, self.mask_dims)
+        return MaskableRecurrentDictRolloutBufferSamples(
+            observations=data.observations,
+            actions=data.actions,
+            old_values=data.old_values,
+            old_log_prob=data.old_log_prob,
+            advantages=data.advantages,
+            returns=data.returns,
+            lstm_states=data.lstm_states,
+            episode_starts=data.episode_starts,
+            mask=data.mask,
+            action_masks=action_masks,
+        )

--- a/sb3_contrib/common/recurrent/maskable/policies.py
+++ b/sb3_contrib/common/recurrent/maskable/policies.py
@@ -1,0 +1,84 @@
+from typing import Optional
+
+import numpy as np
+import torch as th
+
+from sb3_contrib.common.maskable.distributions import make_masked_proba_distribution
+from sb3_contrib.common.recurrent.policies import (
+    RecurrentActorCriticCnnPolicy,
+    RecurrentActorCriticPolicy,
+    RecurrentMultiInputActorCriticPolicy,
+)
+from sb3_contrib.common.recurrent.type_aliases import RNNStates
+
+
+class MaskableRecurrentActorCriticPolicy(RecurrentActorCriticPolicy):
+    """Recurrent policy with support for invalid action masking."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Override the action distribution with maskable version
+        self.action_dist = make_masked_proba_distribution(self.action_space)
+        self._build(self._dummy_schedule)  # rebuild networks
+        self.optimizer = self.optimizer_class(self.parameters(), lr=self._dummy_schedule(1), **self.optimizer_kwargs)
+
+    def forward(
+        self,
+        obs: th.Tensor,
+        lstm_states: RNNStates,
+        episode_starts: th.Tensor,
+        deterministic: bool = False,
+        action_masks: Optional[np.ndarray] = None,
+    ) -> tuple[th.Tensor, th.Tensor, th.Tensor, RNNStates]:
+        actions, values, log_prob, lstm_states = super().forward(obs, lstm_states, episode_starts, deterministic)
+        if action_masks is not None:
+            self.action_dist.apply_masking(action_masks)
+            actions = self.action_dist.get_actions(deterministic=deterministic)
+            log_prob = self.action_dist.log_prob(actions)
+        return actions, values, log_prob, lstm_states
+
+    def evaluate_actions(
+        self,
+        obs: th.Tensor,
+        actions: th.Tensor,
+        lstm_states: RNNStates,
+        episode_starts: th.Tensor,
+        action_masks: Optional[th.Tensor] = None,
+    ) -> tuple[th.Tensor, th.Tensor, th.Tensor]:
+        values, log_prob, entropy = super().evaluate_actions(obs, actions, lstm_states, episode_starts)
+        if action_masks is not None:
+            self.action_dist.apply_masking(action_masks)
+            log_prob = self.action_dist.log_prob(actions)
+            entropy = self.action_dist.entropy()
+        return values, log_prob, entropy
+
+    def _predict(
+        self,
+        observation: th.Tensor,
+        lstm_states: tuple[th.Tensor, th.Tensor],
+        episode_starts: th.Tensor,
+        deterministic: bool = False,
+        action_masks: Optional[np.ndarray] = None,
+    ) -> tuple[th.Tensor, tuple[th.Tensor, ...]]:
+        distribution, lstm_states = self.get_distribution(observation, lstm_states, episode_starts, action_masks)
+        return distribution.get_actions(deterministic=deterministic), lstm_states
+
+    def get_distribution(
+        self,
+        obs: th.Tensor,
+        lstm_states: tuple[th.Tensor, th.Tensor],
+        episode_starts: th.Tensor,
+        action_masks: Optional[np.ndarray] = None,
+    ) -> tuple[th.distributions.Distribution, tuple[th.Tensor, ...]]:
+        distribution, lstm_states = super().get_distribution(obs, lstm_states, episode_starts)
+        if action_masks is not None:
+            distribution.apply_masking(action_masks)
+        return distribution, lstm_states
+
+
+class MaskableRecurrentActorCriticCnnPolicy(MaskableRecurrentActorCriticPolicy, RecurrentActorCriticCnnPolicy):
+    pass
+
+
+class MaskableRecurrentMultiInputActorCriticPolicy(MaskableRecurrentActorCriticPolicy, RecurrentMultiInputActorCriticPolicy):
+    pass

--- a/sb3_contrib/common/recurrent/type_aliases.py
+++ b/sb3_contrib/common/recurrent/type_aliases.py
@@ -31,3 +31,29 @@ class RecurrentDictRolloutBufferSamples(NamedTuple):
     lstm_states: RNNStates
     episode_starts: th.Tensor
     mask: th.Tensor
+
+
+class MaskableRecurrentRolloutBufferSamples(NamedTuple):
+    observations: th.Tensor
+    actions: th.Tensor
+    old_values: th.Tensor
+    old_log_prob: th.Tensor
+    advantages: th.Tensor
+    returns: th.Tensor
+    lstm_states: RNNStates
+    episode_starts: th.Tensor
+    mask: th.Tensor
+    action_masks: th.Tensor
+
+
+class MaskableRecurrentDictRolloutBufferSamples(NamedTuple):
+    observations: TensorDict
+    actions: th.Tensor
+    old_values: th.Tensor
+    old_log_prob: th.Tensor
+    advantages: th.Tensor
+    returns: th.Tensor
+    lstm_states: RNNStates
+    episode_starts: th.Tensor
+    mask: th.Tensor
+    action_masks: th.Tensor

--- a/sb3_contrib/ppo_mask_recurrent/__init__.py
+++ b/sb3_contrib/ppo_mask_recurrent/__init__.py
@@ -1,0 +1,8 @@
+from sb3_contrib.ppo_mask_recurrent.policies import (
+    CnnLstmPolicy,
+    MlpLstmPolicy,
+    MultiInputLstmPolicy,
+)
+from sb3_contrib.ppo_mask_recurrent.ppo_mask_recurrent import MaskableRecurrentPPO
+
+__all__ = ["MaskableRecurrentPPO", "MlpLstmPolicy", "CnnLstmPolicy", "MultiInputLstmPolicy"]

--- a/sb3_contrib/ppo_mask_recurrent/policies.py
+++ b/sb3_contrib/ppo_mask_recurrent/policies.py
@@ -1,0 +1,9 @@
+from sb3_contrib.common.recurrent.maskable.policies import (
+    MaskableRecurrentActorCriticCnnPolicy,
+    MaskableRecurrentActorCriticPolicy,
+    MaskableRecurrentMultiInputActorCriticPolicy,
+)
+
+MlpLstmPolicy = MaskableRecurrentActorCriticPolicy
+CnnLstmPolicy = MaskableRecurrentActorCriticCnnPolicy
+MultiInputLstmPolicy = MaskableRecurrentMultiInputActorCriticPolicy

--- a/sb3_contrib/ppo_mask_recurrent/ppo_mask_recurrent.py
+++ b/sb3_contrib/ppo_mask_recurrent/ppo_mask_recurrent.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, ClassVar, Optional, TypeVar, Union
+
+import numpy as np
+import torch as th
+from gymnasium import spaces
+from stable_baselines3.common.buffers import RolloutBuffer
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
+from stable_baselines3.common.utils import FloatSchedule, explained_variance, obs_as_tensor
+from stable_baselines3.common.vec_env import VecEnv
+
+from sb3_contrib.common.maskable.utils import get_action_masks, is_masking_supported
+from sb3_contrib.common.recurrent.maskable.buffers import (
+    MaskableRecurrentDictRolloutBuffer,
+    MaskableRecurrentRolloutBuffer,
+)
+from sb3_contrib.common.recurrent.maskable.policies import (
+    MaskableRecurrentActorCriticCnnPolicy,
+    MaskableRecurrentActorCriticPolicy,
+    MaskableRecurrentMultiInputActorCriticPolicy,
+)
+from sb3_contrib.common.recurrent.type_aliases import RNNStates
+from sb3_contrib.ppo_recurrent.ppo_recurrent import RecurrentPPO
+
+SelfMaskableRecurrentPPO = TypeVar("SelfMaskableRecurrentPPO", bound="MaskableRecurrentPPO")
+
+
+class MaskableRecurrentPPO(RecurrentPPO):
+    policy_aliases: ClassVar[dict[str, type[MaskableRecurrentActorCriticPolicy]]] = {
+        "MlpLstmPolicy": MaskableRecurrentActorCriticPolicy,
+        "CnnLstmPolicy": MaskableRecurrentActorCriticCnnPolicy,
+        "MultiInputLstmPolicy": MaskableRecurrentMultiInputActorCriticPolicy,
+    }
+    policy: MaskableRecurrentActorCriticPolicy  # type: ignore[assignment]
+
+    def _setup_model(self) -> None:
+        self._setup_lr_schedule()
+        self.set_random_seed(self.seed)
+
+        buffer_cls = (
+            MaskableRecurrentDictRolloutBuffer
+            if isinstance(self.observation_space, spaces.Dict)
+            else MaskableRecurrentRolloutBuffer
+        )
+
+        self.policy = self.policy_class(
+            self.observation_space,
+            self.action_space,
+            self.lr_schedule,
+            use_sde=self.use_sde,
+            **self.policy_kwargs,
+        )
+        self.policy = self.policy.to(self.device)
+
+        lstm = self.policy.lstm_actor
+        single_hidden_state_shape = (lstm.num_layers, self.n_envs, lstm.hidden_size)
+        self._last_lstm_states = RNNStates(
+            (
+                th.zeros(single_hidden_state_shape, device=self.device),
+                th.zeros(single_hidden_state_shape, device=self.device),
+            ),
+            (
+                th.zeros(single_hidden_state_shape, device=self.device),
+                th.zeros(single_hidden_state_shape, device=self.device),
+            ),
+        )
+
+        hidden_state_buffer_shape = (self.n_steps, lstm.num_layers, self.n_envs, lstm.hidden_size)
+
+        self.rollout_buffer = buffer_cls(
+            self.n_steps,
+            self.observation_space,
+            self.action_space,
+            hidden_state_buffer_shape,
+            self.device,
+            gamma=self.gamma,
+            gae_lambda=self.gae_lambda,
+            n_envs=self.n_envs,
+        )
+
+        self.clip_range = FloatSchedule(self.clip_range)
+        if self.clip_range_vf is not None:
+            if isinstance(self.clip_range_vf, (float, int)):
+                assert self.clip_range_vf > 0
+            self.clip_range_vf = FloatSchedule(self.clip_range_vf)
+
+    def collect_rollouts(
+        self,
+        env: VecEnv,
+        callback: BaseCallback,
+        rollout_buffer: RolloutBuffer,
+        n_rollout_steps: int,
+        use_masking: bool = True,
+    ) -> bool:
+        assert isinstance(
+            rollout_buffer,
+            (MaskableRecurrentRolloutBuffer, MaskableRecurrentDictRolloutBuffer),
+        ), "RolloutBuffer doesn't support masking"
+        assert self._last_obs is not None
+        self.policy.set_training_mode(False)
+
+        n_steps = 0
+        rollout_buffer.reset()
+        if self.use_sde:
+            self.policy.reset_noise(env.num_envs)
+
+        if use_masking and not is_masking_supported(env):
+            raise ValueError("Environment does not support action masking. Consider using ActionMasker wrapper")
+
+        callback.on_rollout_start()
+        lstm_states = deepcopy(self._last_lstm_states)
+        action_masks = None
+        while n_steps < n_rollout_steps:
+            if self.use_sde and self.sde_sample_freq > 0 and n_steps % self.sde_sample_freq == 0:
+                self.policy.reset_noise(env.num_envs)
+            with th.no_grad():
+                obs_tensor = obs_as_tensor(self._last_obs, self.device)
+                episode_starts = th.tensor(self._last_episode_starts, dtype=th.float32, device=self.device)
+                if use_masking:
+                    action_masks = get_action_masks(env)
+                actions, values, log_probs, lstm_states = self.policy.forward(
+                    obs_tensor,
+                    lstm_states,
+                    episode_starts,
+                    action_masks=action_masks,
+                )
+            actions_np = actions.cpu().numpy()
+            clipped_actions = actions_np
+            if isinstance(self.action_space, spaces.Box):
+                clipped_actions = np.clip(actions_np, self.action_space.low, self.action_space.high)
+            new_obs, rewards, dones, infos = env.step(clipped_actions)
+            self.num_timesteps += env.num_envs
+            callback.update_locals(locals())
+            if not callback.on_step():
+                return False
+            self._update_info_buffer(infos, dones)
+            n_steps += 1
+            if isinstance(self.action_space, spaces.Discrete):
+                actions_np = actions_np.reshape(-1, 1)
+            for idx, done in enumerate(dones):
+                if (
+                    done
+                    and infos[idx].get("terminal_observation") is not None
+                    and infos[idx].get("TimeLimit.truncated", False)
+                ):
+                    terminal_obs = self.policy.obs_to_tensor(infos[idx]["terminal_observation"])[0]
+                    with th.no_grad():
+                        terminal_lstm_state = (
+                            lstm_states.vf[0][:, idx : idx + 1, :].contiguous(),
+                            lstm_states.vf[1][:, idx : idx + 1, :].contiguous(),
+                        )
+                        episode_starts = th.tensor([False], dtype=th.float32, device=self.device)
+                        terminal_value = self.policy.predict_values(terminal_obs, terminal_lstm_state, episode_starts)[0]
+                    rewards[idx] += self.gamma * terminal_value
+            rollout_buffer.add(
+                self._last_obs,
+                actions_np,
+                rewards,
+                self._last_episode_starts,
+                values,
+                log_probs,
+                lstm_states=self._last_lstm_states,
+                action_masks=action_masks,
+            )
+            self._last_obs = new_obs
+            self._last_episode_starts = dones
+            self._last_lstm_states = lstm_states
+        with th.no_grad():
+            episode_starts = th.tensor(dones, dtype=th.float32, device=self.device)
+            values = self.policy.predict_values(obs_as_tensor(new_obs, self.device), lstm_states.vf, episode_starts)
+        rollout_buffer.compute_returns_and_advantage(last_values=values, dones=dones)
+        callback.on_rollout_end()
+        return True
+
+    def train(self) -> None:
+        self.policy.set_training_mode(True)
+        self._update_learning_rate(self.policy.optimizer)
+        clip_range = self.clip_range(self._current_progress_remaining)
+        if self.clip_range_vf is not None:
+            clip_range_vf = self.clip_range_vf(self._current_progress_remaining)
+        entropy_losses, pg_losses, value_losses, clip_fractions = [], [], [], []
+        continue_training = True
+        for epoch in range(self.n_epochs):
+            approx_kl_divs = []
+            for rollout_data in self.rollout_buffer.get(self.batch_size):
+                actions = rollout_data.actions
+                if isinstance(self.action_space, spaces.Discrete):
+                    actions = rollout_data.actions.long().flatten()
+                mask = rollout_data.mask > 1e-8
+                values, log_prob, entropy = self.policy.evaluate_actions(
+                    rollout_data.observations,
+                    actions,
+                    rollout_data.lstm_states,
+                    rollout_data.episode_starts,
+                    action_masks=rollout_data.action_masks,
+                )
+                values = values.flatten()
+                advantages = rollout_data.advantages
+                if self.normalize_advantage:
+                    advantages = (advantages - advantages[mask].mean()) / (advantages[mask].std() + 1e-8)
+                ratio = th.exp(log_prob - rollout_data.old_log_prob)
+                policy_loss_1 = advantages * ratio
+                policy_loss_2 = advantages * th.clamp(ratio, 1 - clip_range, 1 + clip_range)
+                policy_loss = -th.mean(th.min(policy_loss_1, policy_loss_2)[mask])
+                pg_losses.append(policy_loss.item())
+                clip_fraction = th.mean((th.abs(ratio - 1) > clip_range).float()[mask]).item()
+                clip_fractions.append(clip_fraction)
+                if self.clip_range_vf is None:
+                    values_pred = values
+                else:
+                    values_pred = rollout_data.old_values + th.clamp(
+                        values - rollout_data.old_values,
+                        -clip_range_vf,
+                        clip_range_vf,
+                    )
+                value_loss = th.mean(((rollout_data.returns - values_pred) ** 2)[mask])
+                value_losses.append(value_loss.item())
+                if entropy is None:
+                    entropy_loss = -th.mean(-log_prob[mask])
+                else:
+                    entropy_loss = -th.mean(entropy[mask])
+                entropy_losses.append(entropy_loss.item())
+                loss = policy_loss + self.ent_coef * entropy_loss + self.vf_coef * value_loss
+                with th.no_grad():
+                    log_ratio = log_prob - rollout_data.old_log_prob
+                    approx_kl_div = th.mean(((th.exp(log_ratio) - 1) - log_ratio)[mask]).cpu().numpy()
+                    approx_kl_divs.append(approx_kl_div)
+                if self.target_kl is not None and approx_kl_div > 1.5 * self.target_kl:
+                    continue_training = False
+                    if self.verbose >= 1:
+                        print(f"Early stopping at step {epoch} due to reaching max kl: {approx_kl_div:.2f}")
+                    break
+                self.policy.optimizer.zero_grad()
+                loss.backward()
+                th.nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+                self.policy.optimizer.step()
+            if not continue_training:
+                break
+        self._n_updates += self.n_epochs
+        explained_var = explained_variance(self.rollout_buffer.values.flatten(), self.rollout_buffer.returns.flatten())
+        self.logger.record("train/entropy_loss", np.mean(entropy_losses))
+        self.logger.record("train/policy_gradient_loss", np.mean(pg_losses))
+        self.logger.record("train/value_loss", np.mean(value_losses))
+        self.logger.record("train/approx_kl", np.mean(approx_kl_divs))
+        self.logger.record("train/clip_fraction", np.mean(clip_fractions))
+        self.logger.record("train/loss", loss.item())
+        self.logger.record("train/explained_variance", explained_var)
+        if hasattr(self.policy, "log_std"):
+            self.logger.record("train/std", th.exp(self.policy.log_std).mean().item())
+        self.logger.record("train/n_updates", self._n_updates, exclude="tensorboard")
+        self.logger.record("train/clip_range", clip_range)
+        if self.clip_range_vf is not None:
+            self.logger.record("train/clip_range_vf", clip_range_vf)
+
+    def learn(
+        self: SelfMaskableRecurrentPPO,
+        total_timesteps: int,
+        callback: MaybeCallback = None,
+        log_interval: int = 1,
+        tb_log_name: str = "MaskableRecurrentPPO",
+        reset_num_timesteps: bool = True,
+        use_masking: bool = True,
+        progress_bar: bool = False,
+    ) -> SelfMaskableRecurrentPPO:
+        return super().learn(
+            total_timesteps=total_timesteps,
+            callback=callback,
+            log_interval=log_interval,
+            tb_log_name=tb_log_name,
+            reset_num_timesteps=reset_num_timesteps,
+            use_masking=use_masking,
+            progress_bar=progress_bar,
+        )

--- a/tests/test_invalid_actions.py
+++ b/tests/test_invalid_actions.py
@@ -11,7 +11,7 @@ from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.policies import ActorCriticPolicy
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 
-from sb3_contrib import MaskablePPO
+from sb3_contrib import MaskablePPO, MaskableRecurrentPPO
 from sb3_contrib.common.envs import InvalidActionEnvDiscrete, InvalidActionEnvMultiBinary, InvalidActionEnvMultiDiscrete
 from sb3_contrib.common.maskable.callbacks import MaskableEvalCallback
 from sb3_contrib.common.maskable.evaluation import evaluate_policy
@@ -276,3 +276,10 @@ def test_dict_obs():
     env = ToDictWrapper(env)
     model = MaskablePPO("MultiInputPolicy", env, n_steps=32, seed=8)
     model.learn(32)
+
+
+def test_maskable_recurrent_ppo():
+    env = InvalidActionEnvDiscrete(dim=20, n_invalid_actions=10)
+    model = MaskableRecurrentPPO("MlpLstmPolicy", env, n_steps=16, seed=0)
+    model.learn(32)
+    evaluate_policy(model, env, warn=False)


### PR DESCRIPTION
## Summary
- implement `MaskableRecurrentPPO` combining LSTM and invalid action masking
- add maskable recurrent buffer and policy classes
- expose new algorithm in package
- test simple training run

## Testing
- `make format`
- `make check-codestyle`
- `make pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685c4838468c8324a8ca923645b7c70c