### PR TITLE
Add AMPRecurrentMaskablePPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See documentation for the full list of included features.
 - [PPO with invalid action masking (MaskablePPO)](https://arxiv.org/abs/2006.14171)
 - [PPO with recurrent policy (RecurrentPPO aka PPO LSTM)](https://ppo-details.cleanrl.dev//2021/11/05/ppo-implementation-details/)
 - [PPO with recurrent policy and invalid action masking (RecurrentMaskablePPO)](https://sb3-contrib.readthedocs.io/en/master/modules/ppo_recurrent_mask.html)
+- [RecurrentMaskablePPO with AMP (AMPRecurrentMaskablePPO)](https://sb3-contrib.readthedocs.io/en/master/modules/amp_recurrent_maskable_ppo.html)
 - [Truncated Quantile Critics (TQC)](https://arxiv.org/abs/2005.04269)
 - [Trust Region Policy Optimization (TRPO)](https://arxiv.org/abs/1502.05477)
 - [Batch Normalization in Deep Reinforcement Learning (CrossQ)](https://openreview.net/forum?id=PczQtTsTIX)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ RL Baselines3 Zoo also offers a simple interface to train, evaluate agents and d
   modules/ppo_mask
   modules/ppo_recurrent
   modules/ppo_recurrent_mask
+  modules/amp_recurrent_maskable_ppo
   modules/qrdqn
   modules/tqc
   modules/trpo

--- a/docs/modules/amp_recurrent_maskable_ppo.rst
+++ b/docs/modules/amp_recurrent_maskable_ppo.rst
@@ -1,0 +1,29 @@
+.. _amp_recurrent_maskable_ppo:
+
+.. automodule:: sb3_contrib.ppo_recurrent_mask.amp_recurrent_maskable_ppo
+
+AMPRecurrentMaskablePPO
+=======================
+
+Automatic mixed precision version of :class:`~sb3_contrib.ppo_recurrent_mask.RecurrentMaskablePPO`.
+Other than using AMP during training, the behaviour is the same as in the base algorithm.
+
+Example
+-------
+
+.. code-block:: python
+
+  from sb3_contrib import AMPRecurrentMaskablePPO
+  from sb3_contrib.common.envs import InvalidActionEnvDiscrete
+
+  env = InvalidActionEnvDiscrete(dim=80, n_invalid_actions=60)
+  model = AMPRecurrentMaskablePPO("MlpLstmMaskPolicy", env, verbose=1)
+  model.learn(5_000)
+
+Parameters
+----------
+
+.. autoclass:: AMPRecurrentMaskablePPO
+  :members:
+  :inherited-members:
+

--- a/sb3_contrib/__init__.py
+++ b/sb3_contrib/__init__.py
@@ -4,7 +4,7 @@ from sb3_contrib.ars import ARS
 from sb3_contrib.crossq import CrossQ
 from sb3_contrib.ppo_mask import MaskablePPO
 from sb3_contrib.ppo_recurrent import RecurrentPPO
-from sb3_contrib.ppo_recurrent_mask import RecurrentMaskablePPO
+from sb3_contrib.ppo_recurrent_mask import AMPRecurrentMaskablePPO, RecurrentMaskablePPO
 
 from sb3_contrib.qrdqn import QRDQN
 
@@ -21,8 +21,9 @@ __all__ = [
     "QRDQN",
     "TQC",
     "TRPO",
+    "AMPRecurrentMaskablePPO",
     "CrossQ",
     "MaskablePPO",
-    "RecurrentPPO",
     "RecurrentMaskablePPO",
+    "RecurrentPPO",
 ]

--- a/sb3_contrib/ppo_recurrent_mask/__init__.py
+++ b/sb3_contrib/ppo_recurrent_mask/__init__.py
@@ -1,7 +1,14 @@
 try:
     from .ppo_recurrent_mask import RecurrentMaskablePPO
+    from .amp_recurrent_maskable_ppo import AMPRecurrentMaskablePPO
 except ImportError:
     # This will catch the circular import error and allow the module to be imported without issues.
     pass
 
-__all__ = ["CnnLstmMaskPolicy", "MlpLstmMaskPolicy", "MultiInputLstmMaskPolicy", "RecurrentMaskablePPO"]
+__all__ = [
+    "AMPRecurrentMaskablePPO",
+    "CnnLstmMaskPolicy",
+    "MlpLstmMaskPolicy",
+    "MultiInputLstmMaskPolicy",
+    "RecurrentMaskablePPO",
+]

--- a/sb3_contrib/ppo_recurrent_mask/amp_recurrent_maskable_ppo.py
+++ b/sb3_contrib/ppo_recurrent_mask/amp_recurrent_maskable_ppo.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+import numpy as np
+import torch as th
+from gymnasium import spaces
+from torch.cuda.amp import GradScaler
+from torch import autocast
+
+from stable_baselines3.common.utils import explained_variance
+from sb3_contrib.ppo_recurrent_mask.ppo_recurrent_mask import RecurrentMaskablePPO
+
+SelfAMPRecurrentMaskablePPO = TypeVar("SelfAMPRecurrentMaskablePPO", bound="AMPRecurrentMaskablePPO")
+
+
+class AMPRecurrentMaskablePPO(RecurrentMaskablePPO):
+    """RecurrentMaskablePPO trained using automatic mixed precision (AMP)."""
+
+    def __init__(
+        self,
+        *args: Any,
+        scaler: GradScaler | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        if scaler is None:
+            scaler = GradScaler(enabled=self.device.type == "cuda")
+        self.scaler = scaler
+
+    def train(self) -> None:
+        """Update policy using the currently gathered rollout buffer using AMP."""
+        self.policy.set_training_mode(True)
+        self._update_learning_rate(self.policy.optimizer)
+        clip_range = self.clip_range(self._current_progress_remaining)
+        if self.clip_range_vf is not None:
+            clip_range_vf = self.clip_range_vf(self._current_progress_remaining)
+
+        entropy_losses = []
+        pg_losses, value_losses = [], []
+        clip_fractions = []
+
+        continue_training = True
+
+        for epoch in range(self.n_epochs):
+            approx_kl_divs = []
+            for rollout_data in self.rollout_buffer.get(self.batch_size):
+                actions = rollout_data.actions
+                if isinstance(self.action_space, spaces.Discrete):
+                    actions = rollout_data.actions.long().flatten()
+
+                mask = rollout_data.mask > 1e-8
+
+                with autocast(device_type=self.device.type, enabled=self.scaler.is_enabled()):
+                    values, log_prob, entropy = self.policy.evaluate_actions(
+                        rollout_data.observations,
+                        actions,
+                        rollout_data.lstm_states,
+                        rollout_data.episode_starts,
+                        action_masks=rollout_data.action_masks,
+                    )
+                    values = values.flatten()
+
+                    advantages = rollout_data.advantages
+                    if self.normalize_advantage:
+                        advantages = (advantages - advantages[mask].mean()) / (advantages[mask].std() + 1e-8)
+
+                    ratio = th.exp(log_prob - rollout_data.old_log_prob)
+                    policy_loss_1 = advantages * ratio
+                    policy_loss_2 = advantages * th.clamp(ratio, 1 - clip_range, 1 + clip_range)
+                    policy_loss = -th.mean(th.min(policy_loss_1, policy_loss_2)[mask])
+
+                    if self.clip_range_vf is None:
+                        values_pred = values
+                    else:
+                        values_pred = rollout_data.old_values + th.clamp(
+                            values - rollout_data.old_values, -clip_range_vf, clip_range_vf
+                        )
+                    value_loss = th.mean(((rollout_data.returns - values_pred) ** 2)[mask])
+
+                    if entropy is None:
+                        entropy_loss = -th.mean(-log_prob[mask])
+                    else:
+                        entropy_loss = -th.mean(entropy[mask])
+
+                    loss = policy_loss + self.ent_coef * entropy_loss + self.vf_coef * value_loss
+
+                entropy_losses.append(entropy_loss.item())
+                pg_losses.append(policy_loss.item())
+                value_losses.append(value_loss.item())
+                clip_fraction = th.mean((th.abs(ratio - 1) > clip_range).float()[mask]).item()
+                clip_fractions.append(clip_fraction)
+
+                with th.no_grad():
+                    log_ratio = log_prob - rollout_data.old_log_prob
+                    approx_kl_div = th.mean(((th.exp(log_ratio) - 1) - log_ratio)[mask]).cpu().numpy()
+                    approx_kl_divs.append(approx_kl_div)
+
+                if self.target_kl is not None and approx_kl_div > 1.5 * self.target_kl:
+                    continue_training = False
+                    if self.verbose >= 1:
+                        print(f"Early stopping at step {epoch} due to reaching max kl: {approx_kl_div:.2f}")
+                    break
+
+                self.policy.optimizer.zero_grad()
+                self.scaler.scale(loss).backward()
+                self.scaler.unscale_(self.policy.optimizer)
+                th.nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+                self.scaler.step(self.policy.optimizer)
+                self.scaler.update()
+
+            if not continue_training:
+                break
+
+        self._n_updates += self.n_epochs
+        explained_var = explained_variance(self.rollout_buffer.values.flatten(), self.rollout_buffer.returns.flatten())
+
+        self.logger.record("train/entropy_loss", np.mean(entropy_losses))
+        self.logger.record("train/policy_gradient_loss", np.mean(pg_losses))
+        self.logger.record("train/value_loss", np.mean(value_losses))
+        self.logger.record("train/approx_kl", np.mean(approx_kl_divs))
+        self.logger.record("train/clip_fraction", np.mean(clip_fractions))
+        self.logger.record("train/loss", loss.item())
+        self.logger.record("train/explained_variance", explained_var)
+        if hasattr(self.policy, "log_std"):
+            self.logger.record("train/std", th.exp(self.policy.log_std).mean().item())
+
+        self.logger.record("train/n_updates", self._n_updates, exclude="tensorboard")
+        self.logger.record("train/clip_range", clip_range)
+        if self.clip_range_vf is not None:
+            self.logger.record("train/clip_range_vf", clip_range_vf)

--- a/tests/test_amp_recurrent_mask.py
+++ b/tests/test_amp_recurrent_mask.py
@@ -1,0 +1,23 @@
+from stable_baselines3.common.envs import IdentityEnv
+
+from sb3_contrib import AMPRecurrentMaskablePPO
+from sb3_contrib.common.envs import InvalidActionEnvDiscrete
+from sb3_contrib.common.maskable.evaluation import evaluate_policy
+from sb3_contrib.common.wrappers import ActionMasker
+
+
+def action_mask_fn(env: IdentityEnv) -> list[int]:
+    assert hasattr(env, "state")
+    return [int(i == env.state) for i in range(env.action_space.n)]
+
+
+def test_amp_learn():
+    env = IdentityEnv(dim=4)
+    env = ActionMasker(env, action_mask_fn)
+    model = AMPRecurrentMaskablePPO("MlpLstmMaskPolicy", env, n_steps=8, seed=0)
+    model.learn(64)
+    evaluate_policy(model, env, n_eval_episodes=2, warn=False)
+
+
+def test_amp_env_compatibility():
+    AMPRecurrentMaskablePPO("MlpLstmMaskPolicy", InvalidActionEnvDiscrete(), n_steps=8)


### PR DESCRIPTION
## Summary
- add AMP-based recurrent maskable PPO algorithm
- document AMPRecurrentMaskablePPO
- expose the new class in package init files
- reference it in README and docs index
- test AMPRecurrentMaskablePPO

## Testing
- `ruff check .`
- `black --check .`
- `PYTHONPATH=. pytest tests/test_amp_recurrent_mask.py tests/test_lstm_mask.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68699e26be508324aa5fced381f2c4d1